### PR TITLE
Update blog: DeepSeek V4 vs GPT-5.5 vs Qwen3.6: Which Model Should You Use?

### DIFF
--- a/blog/en/deepseek-v4-vs-gpt-55-vs-qwen36-which-model-should-you-use.md
+++ b/blog/en/deepseek-v4-vs-gpt-55-vs-qwen36-which-model-should-you-use.md
@@ -4,7 +4,7 @@ title: >
  DeepSeek V4 vs GPT-5.5 vs Qwen3.6: Which Model Should You Use?
 author: Lumina Wang
 date: 2026-4-28
-cover: assets.zilliz.com/deepseek_v4_vs_gpt_55_vs_qwen36_which_model_should_you_use_md_1_98e0113041.png
+cover: assets.zilliz.com/blog_cover_narrow_1152x720_87d33982dd.jpg
 tag: Engineering
 recommend: false
 publishToMedium: true
@@ -16,6 +16,7 @@ desc: >
  Compare DeepSeek V4, GPT-5.5, and Qwen3.6 in retrieval, debugging, and long-context tests, then build a Milvus RAG pipeline with DeepSeek V4.
 origin: https://milvus.io/blog/deepseek-v4-vs-gpt-55-vs-qwen36-which-model-should-you-use.md
 ---
+
 
 
 New model releases are moving faster than production teams can evaluate them. DeepSeek V4, GPT-5.5, and Qwen3.6-35B-A3B all look strong on paper, but the harder question for AI application developers is practical: which model should you use for retrieval-heavy systems, coding tasks, long-context analysis, and [RAG pipelines](https://zilliz.com/learn/Retrieval-Augmented-Generation)?
@@ -39,7 +40,7 @@ The [DeepSeek V4-Pro model card](https://huggingface.co/deepseek-ai/DeepSeek-V4-
 
 [**GPT-5.5**](https://openai.com/index/introducing-gpt-5-5/) **is a closed frontier model released by OpenAI on April 23, 2026.** OpenAI positions it for coding, online research, data analysis, document work, spreadsheet work, software operation, and tool-based tasks. The official model docs list `gpt-5.5` with a 1M-token API context window, while Codex and ChatGPT product limits may differ.
 
-OpenAI reports strong coding benchmark results: 82.7% on Terminal-Bench 2.0, 73.1% on Expert-SWE, and 58.6% on SWE-Bench Pro. The tradeoff is price: the official API pricing lists GPT-5.5 at $5 per 1M input tokens and $30 per 1M output tokens, before any product-specific or long-context pricing details.
+OpenAI reports strong coding benchmark results: 82.7% on Terminal-Bench 2.0, 73.1% on Expert-SWE, and 58.6% on SWE-Bench Pro. The tradeoff is price: the official API pricing lists GPT-5.5 at \$5 per 1M input tokens and \$30 per 1M output tokens, before any product-specific or long-context pricing details.
 
 ### Qwen3.6-35B-A3B: A Smaller Active-Parameter Model for Local and Multimodal Workloads
 
@@ -65,14 +66,16 @@ We asked each model three time-sensitive questions using web search where availa
 
 | Question | Expected answer at test time | Source |
 | --- | --- | --- |
-| How much does it cost to generate a 1024×1024 medium-quality image with `gpt-image-2` through the OpenAI API? | `$0.053` | [OpenAI image generation pricing](https://developers.openai.com/api/docs/guides/image-generation) |
+| How much does it cost to generate a 1024×1024 medium-quality image with `gpt-image-2` through the OpenAI API? | `\$0.053` | [OpenAI image generation pricing](https://developers.openai.com/api/docs/guides/image-generation) |
 | What is the No. 1 song on this week's Billboard Hot 100, and who is the artist? | `Choosin' Texas` by Ella Langley | [Billboard Hot 100 chart](https://www.billboard.com/charts/hot-100/) |
 | Who is currently leading the 2026 F1 driver standings? | Kimi Antonelli | [Formula 1 driver standings](https://www.formula1.com/en/results/2026/drivers) |
 
 | Note: These are time-sensitive questions. The expected answers reflect the results at the time we ran the test. |
 | --- |
 
-OpenAI's image pricing page uses the label "medium" rather than "standard" for the $0.053 1024×1024 result, so the question is normalized here to match the current API wording.
+OpenAI's image pricing page uses the label "medium" rather than "standard" for the \
+![blog cover narrow 1152x720](https://assets.zilliz.com/blog_cover_narrow_1152x720_87d33982dd.jpg)
+$0.053 1024×1024 result, so the question is normalized here to match the current API wording.
 
 ![](https://assets.zilliz.com/deepseek_v4_vs_gpt_55_vs_qwen36_which_model_should_you_use_md_2_408d990bb6.png)
 


### PR DESCRIPTION
Updated via Blog Publisher.

**File:** `blog/en/deepseek-v4-vs-gpt-55-vs-qwen36-which-model-should-you-use.md`