### PR TITLE
Add .md extension so the "When AI Agents Do the Work" blog publishes (follow-up to #643)

### DIFF
--- a/blog/en/when-ai-agents-do-the-work-what-do-we-lose.md
+++ b/blog/en/when-ai-agents-do-the-work-what-do-we-lose.md
@@ -3,7 +3,7 @@ id: when-ai-agents-do-the-work-what-do-we-lose.md
 title: >
  When AI Agents Do the Work, What Do We Lose?
 author: Bill Chen
-date: 2026-6-18
+date: 2026-06-18
 cover: assets.zilliz.com/Chat_GPT_Image_Jun_21_2026_10_34_48_PM_d223e44fc5.png
 tag: Engineering
 recommend: false


### PR DESCRIPTION
## What
Renames `blog/en/when-ai-agents-do-the-work-what-do-we-lose` → `blog/en/when-ai-agents-do-the-work-what-do-we-lose.md`, and zero-pads the frontmatter date (`2026-6-18` → `2026-06-18`).

## Why
#643 merged this post **without the `.md` extension**, so the blog build (which only picks up `blog/en/*.md`) never published it — the PR merged, but the article never went live. It was the only file in `blog/en/` missing a `.md` extension (288 with, 1 without). The frontmatter `id` and `origin` already reference the `.md` filename, so only the on-disk name was wrong.

No content changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)