### PR TITLE
Switch blog translation model to deepseek-chat

### DIFF
--- a/.github/workflows/translate.yml
+++ b/.github/workflows/translate.yml
@@ -30,9 +30,7 @@ jobs:
           git config --global user.email "Milvus-doc-bot@zilliz.com"
           git config --global user.name "Milvus-doc-bot"
           touch .env
-          echo CHATGPT_API_URL=${{secrets.CHATGPT_API_URL}} >> .env
           echo CHATGPT_API_KEY=${{secrets.CHATGPT_API_KEY}} >> .env
-          echo CHATGPT_MODEL=${{secrets.CHATGPT_MODEL}} >> .env
           echo GH_TOKEN=${{secrets.GH_TOKEN}} >> .env
           yarn translate
 

--- a/tools/utils.js
+++ b/tools/utils.js
@@ -6,18 +6,12 @@ import { JSDOM } from "jsdom";
 
 const PATH = "/blog/";
 
-// ChatGPT-compatible translation API config. Endpoint, key and model are all
-// injected via environment variables (see .github/workflows/translate.yml).
-// CHATGPT_API_URL is a base URL (e.g. https://token.zasdas.com/v1); the
-// /chat/completions path is appended automatically when it's not already there.
-const CHATGPT_BASE_URL = (
-  process.env.CHATGPT_API_URL || "https://api.openai.com/v1"
-).replace(/\/+$/, "");
-const CHATGPT_API_URL = CHATGPT_BASE_URL.endsWith("/chat/completions")
-  ? CHATGPT_BASE_URL
-  : `${CHATGPT_BASE_URL}/chat/completions`;
+// OpenAI-compatible translation API config. Endpoint and model are fixed here;
+// only the key comes from the environment (see .github/workflows/translate.yml)
+// so it never lands in the repo.
+const CHATGPT_API_URL = "https://token.zasdas.com/v1/chat/completions";
+const CHATGPT_MODEL = "deepseek-chat";
 const CHATGPT_API_KEY = process.env.CHATGPT_API_KEY;
-const CHATGPT_MODEL = process.env.CHATGPT_MODEL || "gpt-4o-mini";
 
 const CHATGPT_HEADERS = {
   "Content-Type": "application/json",
@@ -93,8 +87,9 @@ export function mkdir(filePath) {
   }
 }
 
-// Translate a single string via the ChatGPT API. The content is HTML (produced
-// by md2html), so the model is told to preserve tags and only translate text.
+// Translate a single string via the chat completions API. The content is HTML
+// (produced by md2html), so the model is told to preserve tags and only
+// translate text.
 async function translateText(text, sourceLang, targetLang) {
   // Nothing to translate for empty / whitespace-only strings.
   if (!text || !text.trim()) return text;


### PR DESCRIPTION
## What

The weekly blog translation job was configured to call `gpt-5.5` through the OpenAI-compatible relay, and that model is no longer reachable — every translation run fails.

- `tools/utils.js`: pin the relay endpoint and the model (`deepseek-chat`) directly in the file, dropping the `CHATGPT_API_URL` / `CHATGPT_MODEL` env plumbing. Only `CHATGPT_API_KEY` is still read from the environment, so no credential lands in the repo.
- `.github/workflows/translate.yml`: stop writing the two now-unused secrets into `.env`.

## Verification

Sent a `chat/completions` request to the relay with `model: deepseek-chat` using the CI key — HTTP 200, expected content returned. The relay itself is healthy; only the old model was broken.

## Follow-up for the repo admin

`CHATGPT_API_URL` and `CHATGPT_MODEL` in GitHub Secrets are now unused and can be deleted. `CHATGPT_API_KEY` must stay.

🤖 Generated with [Claude Code](https://claude.com/claude-code)